### PR TITLE
adapt the map to batch launch in SEPAL 

### DIFF
--- a/riskmapjnr/__init__.py
+++ b/riskmapjnr/__init__.py
@@ -12,13 +12,6 @@
 # Standard library imports
 import os
 
-# # Third party imports
-# import matplotlib
-# # Use Agg if no display found
-# if os.name == "posix" and "DISPLAY" not in os.environ:
-#     print("no display found. Using non-interactive Agg backend")
-#     matplotlib.use("Agg")
-
 # Local imports
 from .defrate_per_cat import defrate_per_cat
 from .defor_cat import defor_cat

--- a/riskmapjnr/dist_edge_threshold.py
+++ b/riskmapjnr/dist_edge_threshold.py
@@ -56,8 +56,8 @@ def check_fcc_file(fcc_file, blk_rows=128, verbose=True):
     # ================
     # Check projection
     # ================
-    proj = fcc_ds.GetProjectionRef()
-    if "AUTHORITY[\"EPSG\",\"4326\"]]" in proj:
+    crs=fcc_ds.GetSpatialRef()
+    if not crs.IsProjected():
         msg = ("'fcc_file' cannot be in latlon coordinates "
                "and must be projected to compute euclidean "
                "distances.")

--- a/riskmapjnr/makemap.py
+++ b/riskmapjnr/makemap.py
@@ -432,7 +432,9 @@ def makemap(fcc_file, time_interval,
         csize_km = res[0][3]
         wRMSE_obj = [r[1] for r in res]
         df.loc[:, "wRMSE"] = np.array(wRMSE_obj).flatten()
-
+        pool.close()
+        pool.join()
+        
     # Export the table of results
     df.to_csv(tab_file_map_comp, sep=",", header=True,
               index=False, index_label=False)


### PR DESCRIPTION
Fix #5, Fix #3, Fix #4 

 I tried these modifications in SEPAL in different conditions, Notebook, script and application. They all work. 

- remove the backend management from the lib. If it crash the user should set-up the backend before calling riskmapJNR. No need for specific documentation it's described everywhere on the web in matplotlib related issues. Safer than the previous implementation as there are 100s of patological environments... 
- modify projection check. The global 3857 is a projection in metter but as it derives from 4326 it wasn't working. I changed the test to check exactly what we need: "is it projected"
- join pthe pool execution. THe process can now be launched in non-interactiv conditions. 

Let me know what you think 